### PR TITLE
Fix operation on NVIDIA Jetson

### DIFF
--- a/linux/src/xvcd.c
+++ b/linux/src/xvcd.c
@@ -271,7 +271,7 @@ int main(int argc, char **argv)
 	// Listen on port 2542.
 	//
 	
-	s = socket(AF_INET, SOCK_STREAM, 0);
+	s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 	
 	if (s < 0)
 	{
@@ -292,7 +292,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 	
-	if (listen(s, 0) < 0)
+	if (listen(s, 1) < 0)
 	{
 		perror("listen");
 		return 1;


### PR DESCRIPTION
Fix a couple of issues that showed up on NVIDIA Jetson running Linux for
Tegra (L4T). I'm not sure if these issues show up due to the kernel
version (4.9), the 64-bit ARM architecture, or some other reason.

- Specify the protocol for the socket. Without this, a non-TCP socket is
  created, and TCP connection attempts never reach it.

- Specify a backlog of 1. Without this, the kernel rejects all new TCP
  connections.